### PR TITLE
Fix cannot find .runfiles issue

### DIFF
--- a/tools/travis_wheel/python-binary-and-runfiles.patch
+++ b/tools/travis_wheel/python-binary-and-runfiles.patch
@@ -28,7 +28,15 @@ index cde1e9e..59b7d67 100755
      module_space = stub_filename + '.runfiles'
      if os.path.isdir(module_space):
        break
-+    for mod in site.getsitepackages():
++    package_path = site.getsitepackages()
++    # In case this instance is a string
++    if not isinstance(package_path, list):
++      package_path = [package_path]
++    user_path = site.getusersitepackages()
++    if not isinstance(user_path, list):
++      user_path = [user_path]
++    package_path.extend(user_path)
++    for mod in package_path:
 +      module_space = mod + '/tensorboard/tensorboard' + '.runfiles'
 +      if os.path.isdir(module_space):
 +        return module_space


### PR DESCRIPTION
Fix cannot find .runfiles issue when install tensorboard with `pip install tensorboard --user`